### PR TITLE
docker/metadata-actionのid参照誤りを修正

### DIFF
--- a/.github/workflows/publish_docker_image.yaml
+++ b/.github/workflows/publish_docker_image.yaml
@@ -36,5 +36,5 @@ jobs:
         with:
           context: .
           platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.docker_meta.outputs.tags }},ghcr.io/sacloud/textlint-action:latest
+          tags: ${{ steps.meta.outputs.tags }},ghcr.io/sacloud/textlint-action:latest
           push: true


### PR DESCRIPTION
closes #2

#1 でidを変更したにもかかわらず参照側の変更を忘れていたのを修正